### PR TITLE
fix(android): correctly get the boolean for isHtml

### DIFF
--- a/android/src/main/java/de/einfachhans/emailcomposer/EmailComposer.java
+++ b/android/src/main/java/de/einfachhans/emailcomposer/EmailComposer.java
@@ -17,7 +17,7 @@ public class EmailComposer {
 
         // Body
         String body = call.getString("body", "");
-        CharSequence bodyText = call.getBool("isHtml") ? Html.fromHtml(body) : body;
+        CharSequence bodyText = call.getBoolean("isHtml") ? Html.fromHtml(body) : body;
 
         // To
         List<String> toList = call.getArray("to").toList();


### PR DESCRIPTION
You confused the `getBoolean` and `getBool` for iOS and Android. You already fixed iOS but not Android.