### PR TITLE
fix(android): filter email clients

### DIFF
--- a/android/src/main/java/de/einfachhans/emailcomposer/EmailComposer.java
+++ b/android/src/main/java/de/einfachhans/emailcomposer/EmailComposer.java
@@ -2,13 +2,15 @@ package de.einfachhans.emailcomposer;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.text.Html;
 import com.getcapacitor.JSArray;
-import com.getcapacitor.JSObject;
 import com.getcapacitor.PluginCall;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -44,7 +46,7 @@ public class EmailComposer {
     String[] bcc = new String[bccList.size()];
     bcc = bccList.toArray(bcc);
 
-    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(MAILTO_SCHEME));
+    Intent intent = new Intent(Intent.ACTION_SENDTO, Uri.parse(MAILTO_SCHEME));
     intent.putExtra(Intent.EXTRA_SUBJECT, subject);
     intent.putExtra(Intent.EXTRA_TEXT, bodyText);
     intent.putExtra(Intent.EXTRA_EMAIL, to);
@@ -52,14 +54,24 @@ public class EmailComposer {
     intent.putExtra(Intent.EXTRA_BCC, bcc);
 
     // Attachments
-    this.setAttachments(call, intent);
-
-    return intent;
+    JSArray attachments = call.getArray("attachments", new JSArray());
+    return getIntentAccordingToAttachments(attachments, intent);
   }
 
-  private void setAttachments(PluginCall call, Intent intent) throws JSONException {
-    JSArray attachments = call.getArray("attachments", new JSArray());
-    ArrayList<Uri> uris = new ArrayList();
+  /**
+   * Get the right intent according to the attachments.
+   * In case of no attachments return the original intent.
+   * @param attachments the attachments
+   * @param intent the intent
+   * @return the right intent
+   * @throws JSONException in case of a json parsing error
+   */
+  private Intent getIntentAccordingToAttachments(JSArray attachments, Intent intent) throws JSONException {
+    if (attachments == null || attachments.length() == 0)
+    {
+      return intent;
+    }
+    ArrayList<Uri> uris = new ArrayList<>();
     AssetUtil assets = new AssetUtil(ctx);
 
     for (int i = 0; i < attachments.length(); i++) {
@@ -69,23 +81,59 @@ public class EmailComposer {
       String name = attachment.optString("name");
 
       Uri uri = assets.parse(path, type, name);
-      if (uri != null && uri != Uri.EMPTY) uris.add(uri);
+      if (uri != null && uri != Uri.EMPTY) {
+        uris.add(uri);
+      }
     }
 
     if (uris.isEmpty()) {
-      return;
+      return intent;
+    }
+
+    if (uris.size() == 1) {
+      intent.setAction(Intent.ACTION_SEND).putExtra(Intent.EXTRA_STREAM, uris.get(0));
+      return createFilteredEmailChooser(intent);
     }
 
     intent
       .setAction(Intent.ACTION_SEND_MULTIPLE)
-      .setType("*/*")
+      .setType("application/octet-stream")
       .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
       .putExtra(Intent.EXTRA_STREAM, uris);
+    return createFilteredEmailChooser(intent);
+  }
 
-    if (uris.size() > 1) {
-      return;
+  /**
+   * This creates a chooser intent with only e-mail apps
+   * @param originalIntent the original intent to wrap with the chooser intent
+   * @return a new intent
+   */
+  private Intent createFilteredEmailChooser(Intent originalIntent) {
+    PackageManager pm = this.ctx.getPackageManager();
+
+    // First, get all true email apps by checking mailto support
+    Intent mailtoIntent = new Intent(Intent.ACTION_SENDTO, Uri.parse("mailto:test@example.com"));
+    List<ResolveInfo> emailApps = pm.queryIntentActivities(mailtoIntent, 0);
+
+    // Filter to only include apps that are in both lists
+    List<Intent> emailIntents = new ArrayList<>();
+
+    for (ResolveInfo resolveInfo : emailApps) {
+      String packageName = resolveInfo.activityInfo.packageName;
+
+      // Only include if it's a known email app
+      Intent targetIntent = new Intent(originalIntent);
+      targetIntent.setPackage(packageName);
+      targetIntent.setClassName(packageName, resolveInfo.activityInfo.name);
+      emailIntents.add(targetIntent);
     }
 
-    intent.setAction(Intent.ACTION_SEND).putExtra(Intent.EXTRA_STREAM, uris.get(0));
+    // Create chooser with filtered email apps only
+    Intent chooserIntent = Intent.createChooser(emailIntents.remove(0), "Send email...");
+    if (!emailIntents.isEmpty()) {
+      chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, emailIntents.toArray(new Intent[0]));
+    }
+
+    return chooserIntent;
   }
 }


### PR DESCRIPTION
- Resolves #39

This basically updates the default action type to be `SENT_TO`.
It also check which applications can handle `mailto:` uri with the relevant action and then creates an intent with the relevant apps.

I've tested this on my Android 15 with 0, 1, and 2 files and it seems to work as expected.

Let me know if you need anything else in order to get this merged and released.

I'll be using `patch-package` for now and test it a bit more in production, I'll report back if I see any issues with this code.