### PR TITLE
fix(android): correctly handle empty email clients list

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.SENDTO" />
+      <data android:scheme="mailto" />
+    </intent>
+  </queries>
 </manifest>

--- a/android/src/main/java/de/einfachhans/emailcomposer/EmailComposer.java
+++ b/android/src/main/java/de/einfachhans/emailcomposer/EmailComposer.java
@@ -128,6 +128,10 @@ public class EmailComposer {
       emailIntents.add(targetIntent);
     }
 
+    if (emailIntents.isEmpty()) {
+      return originalIntent;
+    }
+    
     // Create chooser with filtered email apps only
     Intent chooserIntent = Intent.createChooser(emailIntents.remove(0), "Send email...");
     if (!emailIntents.isEmpty()) {


### PR DESCRIPTION
- Fixes #44

This adds the missing queries field in the manifest xml file.
It also adds a check to make sure the list itself isn't empty, just in case the queries are not sufficient.
