### PR TITLE
Remove Cordova dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,6 @@ let package = Package(
             name: "EmailComposerPlugin",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
-                .product(name: "Cordova", package: "capacitor-swift-pm")
             ],
             path: "ios/Sources/EmailComposerPlugin")
     ]


### PR DESCRIPTION
This removes the Cordova dependency from iOS package definition.
I would probably consider trying to create a plugin from scratch and add the files instead of trying to remove things, but that might be a bigger effort.

This PR removes the Cordova dependency so that capacitor won't install that if it's not needed, which is the case for this plugin.